### PR TITLE
Adds atomized key support for `decode/2` and `decode!/2`

### DIFF
--- a/test/yamel_test.exs
+++ b/test/yamel_test.exs
@@ -244,4 +244,37 @@ defmodule YamelTest do
       assert {:error, "Unsupported value: 123"} = Yamel.encode(123)
     end
   end
+
+  describe "decode!/2" do
+    test "when structure is Nested Mappings with atomized keys" do
+      yaml = ~S"""
+      foo: bar
+      zoo:
+        fruit: apple
+        name: steve
+        sport: baseball
+      """
+
+      expected = %{foo: "bar", zoo: %{fruit: "apple", name: "steve", sport: "baseball"}}
+
+      assert Yamel.decode!(yaml, atoms: true) == expected
+    end
+  end
+
+  describe "decode/2" do
+    test "when structure is a Map List with atomized keys" do
+      yaml = ~S"""
+      - foo:
+          a: 1
+          b: 2
+      - bar:
+          c: 3
+          d: 4
+      """
+
+      expected = [%{foo: %{a: 1, b: 2}}, %{bar: %{c: 3, d: 4}}]
+
+      assert Yamel.decode(yaml, atoms: true) == {:ok, expected}
+    end
+  end
 end

--- a/test/yamel_test.exs
+++ b/test/yamel_test.exs
@@ -259,7 +259,7 @@ defmodule YamelTest do
 
       expected = %{foo: "bar", zoo: %{fruit: "apple", name: "steve", sport: "baseball"}}
 
-      assert Yamel.decode!(yaml, atoms: true) == expected
+      assert Yamel.decode!(yaml, keys: :atoms) == expected
     end
   end
 
@@ -276,7 +276,7 @@ defmodule YamelTest do
 
       expected = [%{foo: %{a: 1, b: 2}}, %{bar: %{c: 3, d: 4}}]
 
-      assert Yamel.decode(yaml, atoms: true) == {:ok, expected}
+      assert Yamel.decode(yaml, keys: :atoms) == {:ok, expected}
     end
   end
 end


### PR DESCRIPTION
Adds a keyword list to `decode/2` and `decode!/2` for the user to optionally pass `[atoms: true]` to convert the map keys into atoms (rather than strings).

Thanks for creating this project, @GPrimola! Happy Hacktober! 👻🎃 

Closes #2 